### PR TITLE
add request headers to return items

### DIFF
--- a/app/server.js
+++ b/app/server.js
@@ -15,6 +15,40 @@ app.use(express.json());
 
 // TODO: everything
 
+// request header to return all the items in the database, with optional query to return based on category
+app.get("/api/items", (req, res) => {
+    if (req.query.hasOwnProperty("category")) {
+        return pool.query("SELECT * FROM item WHERE category = $1", [req.query.category])
+        .then(result => {
+            res.json(result.rows);
+        })
+        .catch(error => {
+            console.log(error);
+            res.sendStatus(500);
+        })
+    }
+
+    pool.query("SELECT * FROM item")
+    .then(result => {
+        res.json(result.rows);
+    })
+    .catch(error => {
+        console.log(error);
+        res.sendStatus(500);
+    })
+});
+
+app.get("/api/items/:id", (req, res) => {
+    pool.query("SELECT * FROM item WHERE id = $1", [req.params.id])
+    .then(result => {
+        res.json(result.rows);
+    })
+    .catch(error => {
+        console.log(error);
+        res.sendStatus(500);
+    })
+});
+
 // demo api endpoint that may be removed later
 app.get("/api/item/categories", (req, res) => {
     pool.query("SELECT * FROM item_category")


### PR DESCRIPTION
This PR adds the `/api/items` and the `/api/items/:id` headers to return items from the db.

`/api/items` has an optional `?category=` query to return items in a specific category id
the header will also ignore any other query strings and returns all items if `category` isn't provided