### PR TITLE
fix items not having their quantities incremented

### DIFF
--- a/app/public/pos/ordering/script.js
+++ b/app/public/pos/ordering/script.js
@@ -51,6 +51,7 @@ function addItemToOrder(item) {
 
         // increment quantity (conveniently, it works even though it's a string)
         itemRow.children[0].textContent++;
+        order[id] = parseInt(itemRow.children[0].textContent);
         // also multiple price by quantity
         // if anyone wants to know what toFixed() does https://www.w3schools.com/jsref/jsref_tofixed.asp
         itemRow.children[2].textContent = (

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "scripts": {
         "start": "cd app && node server.js",
         "setup": "psql -U postgres -f setup.sql",
-        "setup-demo": "psql -U postgres -f setup.sql && psql -U postgres -f demo-data.sql",
+        "setup-demo": "psql -U postgres -f setup.sql -f demo-data.sql",
         "prettier": "npx prettier . --write"
     },
     "dependencies": {


### PR DESCRIPTION
fix button not updating the quantity in the order object and updated the `setup-demo` script

Testing:
* run `npm run setup-demo` and see that it only prompts for your password once
* see that it works as normally
* `npm start`
* go to http://localhost:3000/pos/ordering/
* add items to the ticket, with some items having more than 1 quantity
* open inspect element and open the Network Tab
* when you click "Place Order", click on `create`, and click on the Payload tab
* verify the quantities are correct
* go to http://localhost:3000/api/orders
* verify the backend also have the correct data