### PR TITLE
resolving unordered item display once modified

### DIFF
--- a/app/server.js
+++ b/app/server.js
@@ -47,7 +47,7 @@ app.get("/api/auth/test", authentication, (req, res) => {
 app.get("/api/items", (req, res) => {
     if (req.query.hasOwnProperty("category")) {
         return pool
-            .query("SELECT * FROM item WHERE category = $1", [
+            .query("SELECT * FROM item WHERE category = $1 ORDER BY id ASC", [
                 req.query.category,
             ])
             .then((result) => {
@@ -59,7 +59,7 @@ app.get("/api/items", (req, res) => {
             });
     }
 
-    pool.query("SELECT * FROM item")
+    pool.query("SELECT * FROM item ORDER BY id ASC")
         .then((result) => {
             res.json(result.rows);
         })


### PR DESCRIPTION
Added `ORDER BY id ASC`  at the end of the query used to retrieve all the items from the database `item` to ensure that it will maintain its original order when displayed to the user on the frontend.