### PR TITLE
POS Ordering Screen: Part 2

### DIFF
--- a/app/public/pos/ordering/index.html
+++ b/app/public/pos/ordering/index.html
@@ -13,17 +13,19 @@
             <div id="categories" class="section"></div>
             <div id="items" class="section"></div>
             <div id="ticket" class="section">
-                <h2>Order</h2>
-                <table>
-                    <thead>
-                        <tr>
-                            <th style="width: 5%">Qty.</th>
-                            <th style="width: 70%">Item</th>
-                            <th style="width: 25%">Price</th>
-                        </tr>
-                    </thead>
-                    <tbody id="ticket-table"></tbody>
-                </table>
+                <div class="ticket-body">
+                    <h2 class="ticket-title">Ordering</h2>
+                    <table>
+                        <thead>
+                            <tr>
+                                <th style="width: 5%">Qty.</th>
+                                <th style="width: 70%">Item</th>
+                                <th style="width: 25%">Price</th>
+                            </tr>
+                        </thead>
+                        <tbody id="ticket-table"></tbody>
+                    </table>
+                </div>
                 <div>
                     <span>Subtotal: $</span><span id="subtotal">0.00</span>
                 </div>

--- a/app/public/pos/ordering/index.html
+++ b/app/public/pos/ordering/index.html
@@ -33,15 +33,17 @@
                     </div>
                     <div class="footer-item">
                         <span>Taxes</span>
-                        <span>$<span id="subtotal">0.00</span></span>
+                        <span>$<span id="taxes">0.00</span></span>
                     </div>
                     <div class="footer-item">
                         <span>Total</span>
-                        <span>$<span id="subtotal">0.00</span></span>
+                        <span>$<span id="total">0.00</span></span>
                     </div>
                 </div>
                 <div class="buttons">
-                    <button id="order">Place Order</button>
+                    <button id="deleteItem" class="button" disabled>Delete</button>
+                    <button id="clear" class="button">Clear Order</button>
+                    <button id="order" class="button">Place Order</button>
                 </div>
             </div>
         </div>

--- a/app/public/pos/ordering/index.html
+++ b/app/public/pos/ordering/index.html
@@ -41,7 +41,7 @@
                     </div>
                 </div>
                 <div class="buttons">
-                    <button id="deleteItem" class="button" disabled>Delete</button>
+                    <button id="delete-item" class="button" disabled>Delete</button>
                     <button id="clear" class="button">Clear Order</button>
                     <button id="order" class="button">Place Order</button>
                 </div>

--- a/app/public/pos/ordering/index.html
+++ b/app/public/pos/ordering/index.html
@@ -26,10 +26,23 @@
                         <tbody id="ticket-table"></tbody>
                     </table>
                 </div>
-                <div>
-                    <span>Subtotal: $</span><span id="subtotal">0.00</span>
+                <div class="ticket-footer">
+                    <div class="footer-item">
+                        <span>Subtotal</span>
+                        <span>$<span id="subtotal">0.00</span></span></span>
+                    </div>
+                    <div class="footer-item">
+                        <span>Taxes</span>
+                        <span>$<span id="subtotal">0.00</span></span>
+                    </div>
+                    <div class="footer-item">
+                        <span>Total</span>
+                        <span>$<span id="subtotal">0.00</span></span>
+                    </div>
                 </div>
-                <button id="order">Place Order</button>
+                <div class="buttons">
+                    <button id="order">Place Order</button>
+                </div>
             </div>
         </div>
         <div class="bottom">This section will be reserved for later use</div>

--- a/app/public/pos/ordering/script.js
+++ b/app/public/pos/ordering/script.js
@@ -2,10 +2,13 @@ const categoryList = document.getElementById("categories");
 const itemGrid = document.getElementById("items");
 const ticketTable = document.getElementById("ticket-table");
 const subtotal = document.getElementById("subtotal");
+const total = document.getElementById("total");
+const clearOrderButton = document.getElementById("clear");
 const orderButton = document.getElementById("order");
 
 // map of items in order stored as item id: quantity
 let order = {};
+let selectedItem = {};
 
 function fetchItemsByCategoryId(id) {
     fetch(`/api/items?category=${id}`)
@@ -43,6 +46,19 @@ function fetchItemsByCategoryId(id) {
         .catch((error) => console.log(error));
 }
 
+function selectItem(itemRow, itemInfo) {
+    const currentSelectedItem =
+        document.getElementsByClassName("item-selected");
+
+    if (currentSelectedItem.length > 0)
+        currentSelectedItem[0].classList.remove("item-selected");
+
+    itemRow.classList.add("item-selected");
+    selectedItem = itemInfo;
+    console.log(selectedItem);
+    // TODO: add future code here to do stuff with the selected item
+}
+
 function addItemToOrder(item) {
     const { id, name, price } = item;
 
@@ -75,18 +91,7 @@ function addItemToOrder(item) {
         itemPrice.style.textAlign = "right";
         itemPrice.textContent = price;
 
-        itemRow.addEventListener("click", () => {
-            const selectedItem =
-                document.getElementsByClassName("item-selected");
-
-            if (selectedItem.length > 0) {
-                selectedItem[0].classList.remove("item-selected");
-                // TODO: add future code to unselect the item
-            }
-
-            itemRow.classList.add("item-selected");
-            // TODO: add future code here to do stuff with the selected item
-        });
+        itemRow.addEventListener("click", () => selectItem(itemRow, item));
         itemRow.append(itemPrice);
         ticketTable.append(itemRow);
     }
@@ -105,7 +110,15 @@ function updateSubtotal() {
     }
 
     subtotal.textContent = subtotalCount.toFixed(2);
+    // also update total since we aren't handling taxes yet
+    total.textContent = subtotalCount.toFixed(2);
 }
+
+clearOrderButton.addEventListener("click", () => {
+    ticketTable.textContent = "";
+    order = {};
+    selectedItem = {};
+});
 
 orderButton.addEventListener("click", () => {
     if (Object.keys(order).length === 0) return;

--- a/app/public/pos/ordering/script.js
+++ b/app/public/pos/ordering/script.js
@@ -109,15 +109,20 @@ function updateSubtotal() {
             subtotalCount + parseFloat(items[i].children[2].textContent);
     }
 
-    subtotal.textContent = subtotalCount.toFixed(2);
+    updateTotals(subtotalCount);
+}
+
+function updateTotals(price) {
+    subtotal.textContent = price.toFixed(2);
     // also update total since we aren't handling taxes yet
-    total.textContent = subtotalCount.toFixed(2);
+    total.textContent = price.toFixed(2);
 }
 
 clearOrderButton.addEventListener("click", () => {
     ticketTable.textContent = "";
     order = {};
     selectedItem = {};
+    updateTotals(0);
 });
 
 orderButton.addEventListener("click", () => {

--- a/app/public/pos/ordering/script.js
+++ b/app/public/pos/ordering/script.js
@@ -3,7 +3,7 @@ const itemGrid = document.getElementById("items");
 const ticketTable = document.getElementById("ticket-table");
 const subtotal = document.getElementById("subtotal");
 const total = document.getElementById("total");
-const deleteItemButton = document.getElementById("deleteItem");
+const deleteItemButton = document.getElementById("delete-item");
 const clearOrderButton = document.getElementById("clear");
 const orderButton = document.getElementById("order");
 

--- a/app/public/pos/ordering/script.js
+++ b/app/public/pos/ordering/script.js
@@ -3,6 +3,7 @@ const itemGrid = document.getElementById("items");
 const ticketTable = document.getElementById("ticket-table");
 const subtotal = document.getElementById("subtotal");
 const total = document.getElementById("total");
+const deleteItemButton = document.getElementById("deleteItem");
 const clearOrderButton = document.getElementById("clear");
 const orderButton = document.getElementById("order");
 
@@ -46,7 +47,7 @@ function fetchItemsByCategoryId(id) {
         .catch((error) => console.log(error));
 }
 
-function selectItem(itemRow, itemInfo) {
+function selectItem(itemRow, id) {
     const currentSelectedItem =
         document.getElementsByClassName("item-selected");
 
@@ -54,8 +55,9 @@ function selectItem(itemRow, itemInfo) {
         currentSelectedItem[0].classList.remove("item-selected");
 
     itemRow.classList.add("item-selected");
-    selectedItem = itemInfo;
-    console.log(selectedItem);
+    selectedItem.id = id;
+    selectedItem.node = itemRow;
+    deleteItemButton.disabled = false;
     // TODO: add future code here to do stuff with the selected item
 }
 
@@ -91,15 +93,15 @@ function addItemToOrder(item) {
         itemPrice.style.textAlign = "right";
         itemPrice.textContent = price;
 
-        itemRow.addEventListener("click", () => selectItem(itemRow, item));
+        itemRow.addEventListener("click", () => selectItem(itemRow, id));
         itemRow.append(itemPrice);
         ticketTable.append(itemRow);
     }
 
-    updateSubtotal();
+    updateTotals();
 }
 
-function updateSubtotal() {
+function updateTotals() {
     const items = ticketTable.children;
     let subtotalCount = 0;
 
@@ -109,20 +111,29 @@ function updateSubtotal() {
             subtotalCount + parseFloat(items[i].children[2].textContent);
     }
 
-    updateTotals(subtotalCount);
+    subtotal.textContent = subtotalCount.toFixed(2);
+    // also update total since we aren't handling taxes yet
+    total.textContent = subtotalCount.toFixed(2);
 }
 
-function updateTotals(price) {
-    subtotal.textContent = price.toFixed(2);
-    // also update total since we aren't handling taxes yet
-    total.textContent = price.toFixed(2);
-}
+deleteItemButton.addEventListener("click", () => {
+    if (selectedItem.hasOwnProperty("id")) {
+        selectedItem.node.remove();
+        // https://www.w3schools.com/howto/howto_js_remove_property_object.asp
+        delete order[selectedItem.id];
+        selectedItem = {};
+        updateTotals();
+    }
+
+    deleteItemButton.disabled = true;
+});
 
 clearOrderButton.addEventListener("click", () => {
     ticketTable.textContent = "";
     order = {};
     selectedItem = {};
-    updateTotals(0);
+    deleteItemButton.disabled = true;
+    updateTotals();
 });
 
 orderButton.addEventListener("click", () => {

--- a/app/public/pos/ordering/script.js
+++ b/app/public/pos/ordering/script.js
@@ -75,6 +75,18 @@ function addItemToOrder(item) {
         itemPrice.style.textAlign = "right";
         itemPrice.textContent = price;
 
+        itemRow.addEventListener("click", () => {
+            const selectedItem =
+                document.getElementsByClassName("item-selected");
+
+            if (selectedItem.length > 0) {
+                selectedItem[0].classList.remove("item-selected");
+                // TODO: add future code to unselect the item
+            }
+
+            itemRow.classList.add("item-selected");
+            // TODO: add future code here to do stuff with the selected item
+        });
         itemRow.append(itemPrice);
         ticketTable.append(itemRow);
     }

--- a/app/public/pos/ordering/styles.css
+++ b/app/public/pos/ordering/styles.css
@@ -53,7 +53,7 @@ body {
 #items {
     flex: 4;
     display: grid;
-    /* 4 items per row */
+    /* repeat(4, 1fr) = 1fr 1fr 1fr 1fr, so 4 (equal width) items per row */
     grid-template-columns: repeat(4, 1fr);
     grid-gap: 8px;
 }
@@ -74,11 +74,14 @@ body {
 
 #ticket {
     flex: 2;
+    display: flex;
+    flex-direction: column;
     border-left: 1px solid black;
 }
 
 .ticket-body {
     border: 1px solid black;
+    overflow-y: auto;
 }
 
 .ticket-title {
@@ -86,6 +89,26 @@ body {
     border: 1px solid black;
     padding: 8px 4px 4px;
     background-color: #EEA;
+}
+
+.ticket-footer {
+    margin-bottom: auto;
+    border: 2px solid black;
+    border-top: unset;
+}
+
+.footer-item {
+    display: flex;
+    justify-content: space-between;
+}
+
+.buttons {
+    margin-top: 8px;
+}
+
+.item-selected {
+    background-color: #DDD;
+    font-weight: 700;
 }
 
 table {
@@ -96,4 +119,10 @@ table {
 th,
 td {
     border: 1px solid black;
+}
+
+td {
+    box-sizing: border-box;
+    height: 40px;
+    padding: 4px;
 }

--- a/app/public/pos/ordering/styles.css
+++ b/app/public/pos/ordering/styles.css
@@ -103,7 +103,13 @@ body {
 }
 
 .buttons {
+    display: flex;
     margin-top: 8px;
+}
+
+.button {
+    flex: 1;
+    height: 40px;
 }
 
 .item-selected {

--- a/app/public/pos/ordering/styles.css
+++ b/app/public/pos/ordering/styles.css
@@ -89,7 +89,7 @@ tr:hover {
     margin: 0;
     border: 1px solid black;
     padding: 8px 4px 4px;
-    background-color: #EEA;
+    background-color: #eea;
 }
 
 .ticket-footer {
@@ -116,12 +116,12 @@ tr:hover {
 }
 
 #delete-item {
-    background-color: #C00;
+    background-color: #c00;
 }
 
 #delete-item:disabled {
     background-color: #400;
-    color: #AAA;
+    color: #aaa;
 }
 
 /* https://developer.mozilla.org/en-US/docs/Web/CSS/:not */
@@ -130,15 +130,15 @@ tr:hover {
 }
 
 #clear {
-    background-color: #E80;
+    background-color: #e80;
 }
 
 #clear:hover {
-    background-color: #A60;
+    background-color: #a60;
 }
 
 #order {
-    background-color: #00C;
+    background-color: #00c;
 }
 
 #order:hover {
@@ -146,7 +146,7 @@ tr:hover {
 }
 
 .item-selected {
-    background-color: #DDD;
+    background-color: #ddd;
     font-weight: 700;
 }
 

--- a/app/public/pos/ordering/styles.css
+++ b/app/public/pos/ordering/styles.css
@@ -54,7 +54,7 @@ body {
     flex: 4;
     display: grid;
     /* 4 items per row */
-    grid-template-columns: auto auto auto auto;
+    grid-template-columns: repeat(4, 1fr);
     grid-gap: 8px;
 }
 
@@ -77,8 +77,18 @@ body {
     border-left: 1px solid black;
 }
 
-table {
+.ticket-body {
     border: 1px solid black;
+}
+
+.ticket-title {
+    margin: 0;
+    border: 1px solid black;
+    padding: 8px 4px 4px;
+    background-color: #EEA;
+}
+
+table {
     border-collapse: collapse;
     width: 100%;
 }

--- a/app/public/pos/ordering/styles.css
+++ b/app/public/pos/ordering/styles.css
@@ -68,7 +68,8 @@ body {
 }
 
 .category-item:hover,
-.item:hover {
+.item:hover,
+tr:hover {
     background-color: #bbb;
 }
 
@@ -109,7 +110,39 @@ body {
 
 .button {
     flex: 1;
+    border: none;
     height: 40px;
+    color: white;
+}
+
+#delete-item {
+    background-color: #C00;
+}
+
+#delete-item:disabled {
+    background-color: #400;
+    color: #AAA;
+}
+
+/* https://developer.mozilla.org/en-US/docs/Web/CSS/:not */
+#delete-item:hover:not(:disabled) {
+    background-color: #800;
+}
+
+#clear {
+    background-color: #E80;
+}
+
+#clear:hover {
+    background-color: #A60;
+}
+
+#order {
+    background-color: #00C;
+}
+
+#order:hover {
+    background-color: #008;
 }
 
 .item-selected {


### PR DESCRIPTION
This PR updates the layout of the POS order screen (particularly the order ticket) and adds Clear Order and Delete Item buttons.

Testing:
* `npm start`
* go to http://localhost:3000/pos/ordering/
* open inspect element
* add some items to the order
* type in `order` and see that the current items in the order is returned (don't worry about the quantity of the items)
* click on one of the items in the ticket and see that it gets selected
* type in `selectedItem` in the console and see that the selected item data is returned
* click on "Delete" and see that the item is removed from the ticket
* type in `selectedItem` in the console and see that an empty object is returned
* type in `order` and see that the item is removed from the order
* click on "Clear Order"
* verify the order ticket is cleared
* type in `order` and see that it is empty