### PR TITLE
Auth and Routing Part 2

### DIFF
--- a/app/routes/pos.js
+++ b/app/routes/pos.js
@@ -1,0 +1,25 @@
+const express = require("express");
+const posRouter = express.Router();
+const cookieParser = require("cookie-parser");
+const { authentication } = require("./api.js");
+
+// apparently setting the absolute path (probably because of node server.js) works
+// TODO: have mac user test this
+const rootPath = "./";
+
+posRouter.use(cookieParser()); // we need this here otherwise authentication wont work
+posRouter.use(authentication);
+
+posRouter.get("/ordering", (req, res) => {
+    res.sendFile("/public/pos/ordering/index.html", { root: rootPath });
+});
+
+posRouter.get("/ordering/styles.css", (req, res) => {
+    res.sendFile("/public/pos/ordering/styles.css", { root: rootPath });
+});
+
+posRouter.get("/ordering/script.js", (req, res) => {
+    res.sendFile("/public/pos/ordering/script.js", { root: rootPath });
+});
+
+module.exports = { posRouter };

--- a/app/routes/pos.js
+++ b/app/routes/pos.js
@@ -3,23 +3,8 @@ const posRouter = express.Router();
 const cookieParser = require("cookie-parser");
 const { authentication } = require("./api.js");
 
-// apparently setting the absolute path (probably because of node server.js) works
-// TODO: have mac user test this
-const rootPath = "./";
-
 posRouter.use(cookieParser()); // we need this here otherwise authentication wont work
 posRouter.use(authentication);
-
-posRouter.get("/ordering", (req, res) => {
-    res.sendFile("/public/pos/ordering/index.html", { root: rootPath });
-});
-
-posRouter.get("/ordering/styles.css", (req, res) => {
-    res.sendFile("/public/pos/ordering/styles.css", { root: rootPath });
-});
-
-posRouter.get("/ordering/script.js", (req, res) => {
-    res.sendFile("/public/pos/ordering/script.js", { root: rootPath });
-});
+posRouter.use(express.static("public/pos")); // we should probably move the "private" pos folder into a separate directory
 
 module.exports = { posRouter };

--- a/app/routes/store.js
+++ b/app/routes/store.js
@@ -1,0 +1,8 @@
+const express = require("express");
+const storeRouter = express.Router();
+
+// for future use
+
+storeRouter.use(express.static("public/store"));
+
+module.exports = { storeRouter };

--- a/app/server.js
+++ b/app/server.js
@@ -6,12 +6,25 @@ const port = 3000;
 
 const { apiRouter } = require("./routes/api");
 const { posRouter } = require("./routes/pos");
+const { storeRouter } = require("./routes/store");
 
 app.use(express.json());
-app.use(express.static("public/store"));
 
 app.use("/api", apiRouter);
 app.use("/pos", posRouter);
+app.use("/store", storeRouter);
+
+app.get("/", (req, res) => {
+    res.sendFile("/public/index.html", { root: __dirname });
+});
+
+app.get("/style.css", (req, res) => {
+    res.sendFile("/public/style.css", { root: __dirname });
+});
+
+app.get("/index.js", (req, res) => {
+    res.sendFile("/public/index.js", { root: __dirname });
+});
 
 app.listen(port, hostname, () => {
     console.log(`http://${hostname}:${port}`);

--- a/app/server.js
+++ b/app/server.js
@@ -1,5 +1,4 @@
 const express = require("express");
-
 const app = express();
 const hostname = "localhost";
 const port = 3000;
@@ -8,8 +7,9 @@ const { apiRouter } = require("./routes/api");
 const { posRouter } = require("./routes/pos");
 const { storeRouter } = require("./routes/store");
 
-app.use(express.json());
+// TODO: Everything
 
+app.use(express.json());
 app.use("/api", apiRouter);
 app.use("/pos", posRouter);
 app.use("/store", storeRouter);

--- a/app/server.js
+++ b/app/server.js
@@ -5,11 +5,13 @@ const hostname = "localhost";
 const port = 3000;
 
 const { apiRouter } = require("./routes/api");
+const { posRouter } = require("./routes/pos");
 
 app.use(express.json());
-app.use(express.static("public"));
+app.use(express.static("public/store"));
 
 app.use("/api", apiRouter);
+app.use("/pos", posRouter);
 
 app.listen(port, hostname, () => {
     console.log(`http://${hostname}:${port}`);

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
     "packages": {
         "": {
             "dependencies": {
+                "cookie-parser": "^1.4.6",
                 "express": "^4.19.2",
                 "pg": "^8.12.0"
             },
@@ -101,6 +102,26 @@
             "version": "0.6.0",
             "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
             "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/cookie-parser": {
+            "version": "1.4.6",
+            "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.6.tgz",
+            "integrity": "sha512-z3IzaNjdwUC2olLIB5/ITd0/setiaFMLYiZJle7xg5Fe9KWAceil7xszYfHHBtDFYLSgJduS2Ty0P1uJdPDJeA==",
+            "dependencies": {
+                "cookie": "0.4.1",
+                "cookie-signature": "1.0.6"
+            },
+            "engines": {
+                "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/cookie-parser/node_modules/cookie": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+            "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
             "engines": {
                 "node": ">= 0.6"
             }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
         "prettier": "npx prettier . --write"
     },
     "dependencies": {
+        "cookie-parser": "^1.4.6",
         "express": "^4.19.2",
         "pg": "^8.12.0"
     },


### PR DESCRIPTION
This PR adds in (test) authentication in the POS route and cleans up the routes (for future use)
(API authentication not implemented yet)

Authentication Link: http://localhost:3000/api/auth/pos

Testing:
* `npm i`
* `npm start`
* go to any POS route, such as http://localhost:3000/pos/ordering/
* see that you are unauthorized
* go to http://localhost:3000/store/account-management/createConsumerAccount.html (we should definitely rename this)
* verify you have access to it as normally
* go to the authentication link above and verify a 200 OK response is returned
* go to http://localhost:3000/pos/ordering/ and verify the page loads as normally