### PR TITLE
Orders refinement

### DIFF
--- a/app/routes/api.js
+++ b/app/routes/api.js
@@ -154,17 +154,17 @@ apiRouter.get("/auth/pos/logout", (req, res) => {
 apiRouter.get("/items", (req, res) => {
     if (req.query.hasOwnProperty("category")) {
         return query(
-            "SELECT * FROM item WHERE category = $1 ORDER BY id ASC",
+            "SELECT * FROM item WHERE category = $1 AND is_deleted = false ORDER BY id ASC",
             [req.query.category],
             res,
         );
     }
 
-    query("SELECT * FROM item ORDER BY id ASC", [], res);
+    query("SELECT * FROM item AND is_deleted = false ORDER BY id ASC", [], res);
 });
 
 apiRouter.get("/items/:id", (req, res) => {
-    query("SELECT * FROM item WHERE id = $1", [req.params.id], res);
+    query("SELECT * FROM item WHERE id = $1 AND is_deleted = false", [req.params.id], res);
 });
 
 // demo api endpoint that may be removed later
@@ -259,7 +259,7 @@ apiRouter.put("/items/:id", (req, res) => {
     const id = req.params.id;
 
     query(
-        "UPDATE item SET name = $1, description = $2, price = $3 WHERE id = $4",
+        "UPDATE item SET name = $1, description = $2, price = $3 WHERE id = $4 AND is_deleted = false",
         [name, description, price, id],
         res,
         true,
@@ -276,7 +276,7 @@ apiRouter.delete("/items/:id", (req, res) => {
 
     const id = params.id;
 
-    query("DELETE FROM item WHERE id = $1", [id], res);
+    query("UPDATE item SET is_deleted = true WHERE id = $1", [id], res, true);
 });
 
 apiRouter.post("/orders/create", (req, res) => {

--- a/app/routes/api.js
+++ b/app/routes/api.js
@@ -332,8 +332,10 @@ apiRouter.post("/orders/create", async (req, res) => {
     }
 
     // create the order and the corresponding order_items;
+    // conveniently, postgres has a CURRENT_DATE function
+    //https://www.postgresql.org/docs/current/functions-datetime.html#FUNCTIONS-DATETIME-CURRENT
     pool.query(
-        "INSERT INTO orders (items, subtotal) VALUES ($1, $2) RETURNING id",
+        "INSERT INTO orders (items, subtotal, date_ordered) VALUES ($1, $2, CURRENT_DATE) RETURNING id",
         [JSON.stringify(body.order), body.subtotal],
     )
         .then((result) => {

--- a/app/routes/api.js
+++ b/app/routes/api.js
@@ -88,6 +88,8 @@ const cookieOptions = {
     sameSite: "strict", // only sent to this domain
 };
 
+// accounts and authtication
+
 // this was pain
 apiRouter.post("/auth/pos/login", async (req, res) => {
     const body = req.body;
@@ -150,6 +152,55 @@ apiRouter.get("/auth/pos/logout", (req, res) => {
         });
 });
 
+// TODO: update this to new schema
+apiRouter.post("/accounts/add", (req, res) => {
+    const body = req.body;
+
+    if (
+        !body.hasOwnProperty("username") ||
+        !body.hasOwnProperty("firstname") ||
+        !body.hasOwnProperty("lastname") ||
+        !body.hasOwnProperty("accountType") ||
+        body.username.length > 50 ||
+        body.username.length < 1 ||
+        body.firstname.length > 50 ||
+        body.firstname.length < 1 ||
+        body.lastname.length > 50 ||
+        body.lastname.length < 1 ||
+        body.accountType.length > 50 ||
+        body.accountType.length < 1
+    ) {
+        return res.sendStatus(400);
+    }
+
+    const { username, firstname, lastname, accountType } = req.body;
+
+    query(
+        "INSERT INTO account(username, first_name, last_name, account_type) VALUES($1, $2, $3, $4)",
+        [username, firstname, lastname, accountType],
+        res,
+        true,
+    );
+});
+
+// item categories
+
+apiRouter.post("/category/add", (req, res) => {
+    const body = req.body;
+
+    if (
+        !body.hasOwnProperty("name") ||
+        body.name.length > 50 ||
+        body.name.length < 1
+    ) {
+        return res.sendStatus(400);
+    }
+
+    query("INSERT INTO item_category(name) VALUES($1)", [body.name], res, true);
+});
+
+// items
+
 // request header to return all the items in the database, with optional query to return based on category
 apiRouter.get("/items", (req, res) => {
     if (req.query.hasOwnProperty("category")) {
@@ -197,50 +248,6 @@ apiRouter.post("/item/add", (req, res) => {
     );
 });
 
-apiRouter.post("/category/add", (req, res) => {
-    const body = req.body;
-
-    if (
-        !body.hasOwnProperty("name") ||
-        body.name.length > 50 ||
-        body.name.length < 1
-    ) {
-        return res.sendStatus(400);
-    }
-
-    query("INSERT INTO item_category(name) VALUES($1)", [body.name], res, true);
-});
-
-apiRouter.post("/accounts/add", (req, res) => {
-    const body = req.body;
-
-    if (
-        !body.hasOwnProperty("username") ||
-        !body.hasOwnProperty("firstname") ||
-        !body.hasOwnProperty("lastname") ||
-        !body.hasOwnProperty("accountType") ||
-        body.username.length > 50 ||
-        body.username.length < 1 ||
-        body.firstname.length > 50 ||
-        body.firstname.length < 1 ||
-        body.lastname.length > 50 ||
-        body.lastname.length < 1 ||
-        body.accountType.length > 50 ||
-        body.accountType.length < 1
-    ) {
-        return res.sendStatus(400);
-    }
-
-    const { username, firstname, lastname, accountType } = req.body;
-
-    query(
-        "INSERT INTO account(username, first_name, last_name, account_type) VALUES($1, $2, $3, $4)",
-        [username, firstname, lastname, accountType],
-        res,
-        true,
-    );
-});
-
 // PUT API endpoint to update exisiting item
 apiRouter.put("/items/:id", (req, res) => {
     const body = req.body;
@@ -278,6 +285,8 @@ apiRouter.delete("/items/:id", (req, res) => {
 
     query("UPDATE item SET is_deleted = true WHERE id = $1", [id], res, true);
 });
+
+// orders
 
 apiRouter.post("/orders/create", (req, res) => {
     const body = req.body;

--- a/setup.sql
+++ b/setup.sql
@@ -13,6 +13,7 @@ CREATE TABLE item (
 	category INT NOT NULL,
 	description TEXT NOT NULL,
 	price DECIMAL(10,2),
+	is_deleted BOOLEAN DEFAULT false,
 	CONSTRAINT fk_item_category FOREIGN KEY (category) REFERENCES item_category(id)
 );
 
@@ -43,8 +44,8 @@ CREATE TABLE orders (
 	discount DECIMAL(10,2),
 	tips DECIMAL(10, 2),
 	total DECIMAL(10,2),
-	is_paid BOOLEAN,
-	is_void BOOLEAN,
+	is_paid BOOLEAN DEFAULT false,
+	is_void BOOLEAN DEFAULT false,
 	date_ordered DATE -- TODO: change this to NOT NULL
 );
 

--- a/setup.sql
+++ b/setup.sql
@@ -17,18 +17,6 @@ CREATE TABLE item (
 	CONSTRAINT fk_item_category FOREIGN KEY (category) REFERENCES item_category(id)
 );
 
--- if we are going to use order_item, we should remove the foreign key, and add in
--- a name and price column in case the user want to delete an item and you won't have to
--- delete the corresponding order_item
--- otherwise we could add an is_deleted boolean in the item table so the item is soft deleted
-CREATE TABLE order_item (
-	id SERIAL PRIMARY KEY,
-	item_id INT NOT NULL,
-	quantity INT NOT NULL,
-	date_ordered DATE NOT NULL,
-	CONSTRAINT fk_item_id FOREIGN KEY (item_id) REFERENCES item(id)
-);
-
 CREATE TABLE cart_item (
 	id SERIAL PRIMARY KEY,
 	item_id INT NOT NULL,
@@ -39,7 +27,7 @@ CREATE TABLE cart_item (
 --wip
 CREATE TABLE orders (
 	id SERIAL PRIMARY KEY,
-	items JSON, -- revisit for possible junction table implementation (order_item)
+	items JSON, -- TODO: remove this once this isn't used anymore (deprecated)
 	subtotal DECIMAL(10,2),
 	discount DECIMAL(10,2),
 	tips DECIMAL(10, 2),
@@ -47,6 +35,15 @@ CREATE TABLE orders (
 	is_paid BOOLEAN DEFAULT false,
 	is_void BOOLEAN DEFAULT false,
 	date_ordered DATE -- TODO: change this to NOT NULL
+);
+
+CREATE TABLE order_item (
+	id SERIAL PRIMARY KEY,
+	item_id INT NOT NULL,
+	quantity INT NOT NULL,
+	order_id INT NOT NULL,
+	CONSTRAINT fk_item_id FOREIGN KEY (item_id) REFERENCES item(id),
+	CONSTRAINT fk_order_id FOREIGN KEY (order_id) REFERENCES orders(id)
 );
 
 CREATE TABLE discounts (

--- a/setup.sql
+++ b/setup.sql
@@ -34,7 +34,7 @@ CREATE TABLE orders (
 	total DECIMAL(10,2),
 	is_paid BOOLEAN DEFAULT false,
 	is_void BOOLEAN DEFAULT false,
-	date_ordered DATE -- TODO: change this to NOT NULL
+	date_ordered DATE NOT NULL -- TODO: change this to NOT NULL
 );
 
 CREATE TABLE order_item (

--- a/setup.sql
+++ b/setup.sql
@@ -24,7 +24,6 @@ CREATE TABLE cart_item (
 	CONSTRAINT fk_item_id FOREIGN KEY (item_id) REFERENCES item(id)
 );
 
---wip
 CREATE TABLE orders (
 	id SERIAL PRIMARY KEY,
 	items JSON, -- TODO: remove this once this isn't used anymore (deprecated)
@@ -34,7 +33,7 @@ CREATE TABLE orders (
 	total DECIMAL(10,2),
 	is_paid BOOLEAN DEFAULT false,
 	is_void BOOLEAN DEFAULT false,
-	date_ordered DATE NOT NULL -- TODO: change this to NOT NULL
+	date_ordered DATE NOT NULL
 );
 
 CREATE TABLE order_item (


### PR DESCRIPTION
This PR updates how items, orders, and order items are stored in the DB.

- Change item deletion to be a `is_deleted` boolean value, so that if an item is deleted, it will be soft deleted
- Implemented the use of `order_item` in the backend, will be used in sales reporting and other whatnot
  - also added an endpoint to return the order items based on the order id
- Orders now uses the `date_ordered` column
- Added validation without testing the validation (i hope it works lol)

Testing:
- `npm run setup-demo`
- `npm start`
- create some orders at http://localhost:3000/pos/ordering/ and place them
- verify ordering works as normal
- go to http://localhost:3000/api/orders/1
- verify the date_ordered field is the current date
- go to http://localhost:3000/api/orders/items/1
- verify the order items are there
- verify any other code that uses orders works normally